### PR TITLE
Add live tennis dashboard example

### DIFF
--- a/live_tennis_dashboard/README.md
+++ b/live_tennis_dashboard/README.md
@@ -1,0 +1,69 @@
+# Live tennis dashboard
+
+[![Open in marimo](https://marimo.io/shield.svg)](https://marimo.app/github.com/marimo-team/examples/blob/main/live_tennis_dashboard/live_tennis_dashboard.py)
+
+**A reactive scoreboard for live tennis.** This notebook pulls live matches
+and upcoming fixtures from the [Live Tennis
+API](https://livetennisapi.com) — ATP, WTA, Challenger, ITF and juniors — and
+renders them as filterable tables with set score, in-game points, a serving
+marker and a **break-point marker derived from the raw score**. A tour
+dropdown and a player-search box filter everything reactively.
+
+**No API key is needed to try it**: without a key the notebook renders
+bundled, clearly-labeled sample data (`sample_data.json`, fictional players),
+so it works out of the box — including in the online playground, via a small
+inline fallback.
+
+<img src="https://raw.githubusercontent.com/livetennisapi/livetennis-marimo/main/assets/preview.png" width="700px" />
+
+## Running this notebook
+
+Open this notebook in [our online
+playground](https://marimo.app/github.com/marimo-team/examples/blob/main/live_tennis_dashboard/live_tennis_dashboard.py)
+or run it locally.
+
+### Running locally
+
+The requirements of each notebook are serialized in them as a top-level
+comment. Here are the steps to run the notebook:
+
+1. [Install `uv`](https://github.com/astral-sh/uv/?tab=readme-ov-file#installation)
+2. Open an example with `uvx marimo edit --sandbox <notebook-url>`
+
+> [!TIP]
+> The [`--sandbox`
+> flag](https://docs.marimo.io/guides/package_reproducibility/) opens the
+> notebook in an isolated virtual environment, automatically installing the
+> notebook's dependencies 📦
+
+You can also open notebooks without `uv`, in which case you'll need to
+manually [install marimo](https://docs.marimo.io/getting_started/index.html#installation)
+first. Then run `marimo edit <notebook-url>`; however, you'll also need to
+install the requirements yourself.
+
+## Using your own API key (live data)
+
+1. Get a key — the [free tier](https://livetennisapi.com/subscribe/free) is
+   self-serve (no card): 30 requests/minute, 100/day. Historical results and
+   market prices are paid tiers; this notebook only uses FREE endpoints
+   (`GET /matches?status=live`, `GET /fixtures`).
+2. Set `LIVETENNIS_API_KEY` in your environment before starting marimo, or
+   paste the key into the field at the top of the notebook.
+
+The notebook is deliberately polite to that budget: refresh is manual by
+default, the optional auto-refresh intervals are capped at 1 minute or
+slower, and one refresh costs 2 requests.
+
+## Adapting this notebook
+
+- **Other match states**: point the fetch cell at `/matches?status=upcoming`
+  (also FREE).
+- **More filters**: `/matches` accepts `player`, `country` and `from`/`to`
+  query parameters.
+- **Player bios**: join `/players?search=` (FREE) on the names in the tables.
+- **Break-point logic**: the marker is computed client-side in the
+  `break_point` function (receiver at AD, or at 40 while the server is below
+  40; tiebreaks excluded) — extend it for set/match points.
+- Full API reference:
+  [docs.livetennisapi.com](https://docs.livetennisapi.com)
+  ([openapi.yaml](https://docs.livetennisapi.com/openapi.yaml)).

--- a/live_tennis_dashboard/live_tennis_dashboard.py
+++ b/live_tennis_dashboard/live_tennis_dashboard.py
@@ -35,6 +35,7 @@ def _(mo):
 @app.cell
 def _():
     import marimo as mo
+
     return (mo,)
 
 
@@ -64,9 +65,9 @@ def _(mo):
 
 @app.cell
 def _(api_key_box, os):
-    api_key = api_key_box.value.strip() or os.environ.get(
-        "LIVETENNIS_API_KEY", ""
-    ).strip()
+    api_key = (
+        api_key_box.value.strip() or os.environ.get("LIVETENNIS_API_KEY", "").strip()
+    )
     return (api_key,)
 
 
@@ -246,9 +247,7 @@ def _(API_BASE, SAMPLE, api_key, mo, refresher, requests, tour_select):
 
     if api_key:
         try:
-            live_matches = _get("/matches", {"status": "live", **_tour_params})[
-                "data"
-            ]
+            live_matches = _get("/matches", {"status": "live", **_tour_params})["data"]
             fixtures = _get("/fixtures", {"limit": 25, **_tour_params})["data"]
             is_sample = False
             data_banner = mo.callout(
@@ -360,8 +359,7 @@ def _(
         if _query:
             players = match.get("players") or {}
             names = " ".join(
-                (players.get(side) or {}).get("name") or ""
-                for side in ("p1", "p2")
+                (players.get(side) or {}).get("name") or "" for side in ("p1", "p2")
             ).lower()
             return _query in names
         return True
@@ -386,9 +384,7 @@ def _(
                 "Sets": fmt_sets(_score),
                 "Games": fmt_games(_score),
                 "Points": fmt_points(_score),
-                "Break point": (
-                    "P2" if _serving == "P1" else "P1"
-                ) if _bp else "",
+                "Break point": ("P2" if _serving == "P1" else "P1") if _bp else "",
             }
         )
 
@@ -419,9 +415,7 @@ def _(fixtures, is_sample, mo, player_search, tour_select):
         # Sample mode approximates it: Fixture.tour is the record's own
         # granular value (e.g. "challenger_men"), so match by prefix.
         if tour_select.value and is_sample:
-            if not (fixture.get("tour") or "").lower().startswith(
-                tour_select.value
-            ):
+            if not (fixture.get("tour") or "").lower().startswith(tour_select.value):
                 return False
         if _query:
             names = (

--- a/live_tennis_dashboard/live_tennis_dashboard.py
+++ b/live_tennis_dashboard/live_tennis_dashboard.py
@@ -1,0 +1,477 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "marimo",
+#     "requests==2.32.4",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.23.16"
+app = marimo.App(width="medium")
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(
+        """
+        # Live tennis dashboard
+
+        A reactive scoreboard on the [Live Tennis API](https://livetennisapi.com):
+        live matches with set score, in-game points, who is serving and a derived
+        **break-point marker**, plus upcoming fixtures — across ATP, WTA,
+        Challenger, ITF and juniors.
+
+        **No key needed to look around** — without a key the notebook renders
+        bundled, clearly-labeled sample data. Add a
+        [free API key](https://livetennisapi.com/subscribe/free) to see the real
+        live picture.
+        """
+    )
+    return
+
+
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell
+def _():
+    import json
+    import os
+    from pathlib import Path
+
+    import requests
+
+    API_BASE = "https://api.livetennisapi.com/api/public/v1"
+    return API_BASE, Path, json, os, requests
+
+
+@app.cell
+def _(mo):
+    api_key_box = mo.ui.text(
+        kind="password",
+        label="API key (optional)",
+        placeholder="paste a key here, or set LIVETENNIS_API_KEY in your environment",
+        full_width=True,
+    )
+    api_key_box
+    return (api_key_box,)
+
+
+@app.cell
+def _(api_key_box, os):
+    api_key = api_key_box.value.strip() or os.environ.get(
+        "LIVETENNIS_API_KEY", ""
+    ).strip()
+    return (api_key,)
+
+
+@app.cell
+def _(mo):
+    tour_select = mo.ui.dropdown(
+        options={
+            "All tours": None,
+            "ATP": "atp",
+            "WTA": "wta",
+            "Challenger": "challenger",
+            "ITF": "itf",
+            "Juniors": "juniors",
+        },
+        value="All tours",
+        label="Tour",
+    )
+    player_search = mo.ui.text(
+        label="Player search", placeholder="filter by player name"
+    )
+    refresher = mo.ui.refresh(
+        label="Refresh", options=["1m", "5m", "10m"], default_interval=None
+    )
+    mo.vstack(
+        [
+            mo.hstack([tour_select, player_search, refresher], justify="start"),
+            mo.md(
+                "_Budget note: one refresh = 2 API requests (live matches +"
+                " fixtures). The free tier allows 30 requests/minute and"
+                " 100/day, so auto-refresh intervals here are deliberately"
+                " capped at 1 minute or slower — leave it on manual unless you"
+                " are watching a match._"
+            ),
+        ]
+    )
+    return player_search, refresher, tour_select
+
+
+@app.cell
+def _(Path, json, mo):
+    def _load_sample():
+        """Load bundled sample_data.json; fall back to a tiny inline sample."""
+        candidates = []
+        try:
+            nb_dir = mo.notebook_dir()
+            if nb_dir is not None:
+                candidates.append(Path(nb_dir) / "sample_data.json")
+        except Exception:
+            pass
+        candidates.append(Path("sample_data.json"))
+        for candidate in candidates:
+            try:
+                if candidate.is_file():
+                    return json.loads(candidate.read_text())
+            except Exception:
+                continue
+        return _INLINE_SAMPLE
+
+    # Minimal inline fallback so the notebook still renders when
+    # sample_data.json is not next to it (e.g. in the online playground).
+    _INLINE_SAMPLE = {
+        "matches": {
+            "data": [
+                {
+                    "id": 910001,
+                    "tournament": "Sample Open",
+                    "tour": "atp",
+                    "surface": "hard",
+                    "round": "Quarterfinal",
+                    "round_code": "QF",
+                    "status": "live",
+                    "is_doubles": False,
+                    "players": {
+                        "p1": {
+                            "id": 81001,
+                            "name": "Daniel Okafor",
+                            "country": "NG",
+                            "ranking": 14,
+                        },
+                        "p2": {
+                            "id": 81002,
+                            "name": "Tomas Vanek",
+                            "country": "CZ",
+                            "ranking": 31,
+                        },
+                    },
+                    "score": {
+                        "sets": [1, 0],
+                        "games": [[6, 4], [3, 2]],
+                        "points": ["30", "40"],
+                        "server": 1,
+                        "is_tiebreak": False,
+                    },
+                },
+                {
+                    "id": 910002,
+                    "tournament": "Riverside Classic",
+                    "tour": "wta",
+                    "surface": "clay",
+                    "round": "Semifinal",
+                    "round_code": "SF",
+                    "status": "live",
+                    "is_doubles": False,
+                    "players": {
+                        "p1": {
+                            "id": 82001,
+                            "name": "Sofia Marchetti",
+                            "country": "IT",
+                            "ranking": 8,
+                        },
+                        "p2": {
+                            "id": 82002,
+                            "name": "Hana Kobayashi",
+                            "country": "JP",
+                            "ranking": 22,
+                        },
+                    },
+                    "score": {
+                        "sets": [0, 1],
+                        "games": [[4, 6], [6, 6]],
+                        "points": ["5", "3"],
+                        "server": 2,
+                        "is_tiebreak": True,
+                    },
+                },
+            ]
+        },
+        "fixtures": {
+            "data": [
+                {
+                    "id": 920001,
+                    "event_date": "2026-08-16",
+                    "start_time": "2026-08-16T15:00:00Z",
+                    "tour": "atp",
+                    "tournament": "Sample Open",
+                    "round": "Quarterfinal",
+                    "surface": "hard",
+                    "player1_name": "Andrei Popescu",
+                    "player2_name": "Louis Moreau",
+                    "status": "scheduled",
+                },
+                {
+                    "id": 920002,
+                    "event_date": "2026-08-16",
+                    "start_time": "2026-08-16T17:30:00Z",
+                    "tour": "wta",
+                    "tournament": "Riverside Classic",
+                    "round": "Semifinal",
+                    "surface": "clay",
+                    "player1_name": "Emma Lindqvist",
+                    "player2_name": "Carla Duarte",
+                    "status": "scheduled",
+                },
+            ]
+        },
+    }
+
+    SAMPLE = _load_sample()
+    return (SAMPLE,)
+
+
+@app.cell
+def _(API_BASE, SAMPLE, api_key, mo, refresher, requests, tour_select):
+    refresher  # referencing the refresh element re-runs this cell on refresh
+
+    def _get(path, params):
+        response = requests.get(
+            f"{API_BASE}{path}",
+            params=params,
+            headers={"X-API-Key": api_key},
+            timeout=15,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    _tour_params = {"tour": tour_select.value} if tour_select.value else {}
+
+    if api_key:
+        try:
+            live_matches = _get("/matches", {"status": "live", **_tour_params})[
+                "data"
+            ]
+            fixtures = _get("/fixtures", {"limit": 25, **_tour_params})["data"]
+            is_sample = False
+            data_banner = mo.callout(
+                mo.md(
+                    "**Live data** from api.livetennisapi.com — press Refresh"
+                    " for the latest scores."
+                ),
+                kind="success",
+            )
+        except Exception as request_error:
+            live_matches = SAMPLE["matches"]["data"]
+            fixtures = SAMPLE["fixtures"]["data"]
+            is_sample = True
+            data_banner = mo.callout(
+                mo.md(
+                    f"API request failed (`{request_error}`) — showing"
+                    " **sample data** instead."
+                ),
+                kind="warn",
+            )
+    else:
+        live_matches = SAMPLE["matches"]["data"]
+        fixtures = SAMPLE["fixtures"]["data"]
+        is_sample = True
+        data_banner = mo.callout(
+            mo.md(
+                "**Sample data** (fictional players, frozen scores) — no API"
+                " key set. Paste a key above or set `LIVETENNIS_API_KEY` to"
+                " see real live matches."
+            ),
+            kind="info",
+        )
+    data_banner
+    return fixtures, is_sample, live_matches
+
+
+@app.cell
+def _():
+    def fmt_sets(score):
+        sets = (score or {}).get("sets") or []
+        return f"{sets[0]}-{sets[1]}" if len(sets) == 2 else ""
+
+    def fmt_games(score):
+        games = (score or {}).get("games") or []
+        if len(games) == 2 and games[0]:
+            return " ".join(f"{a}-{b}" for a, b in zip(games[0], games[1]))
+        return ""
+
+    def fmt_points(score):
+        points = (score or {}).get("points") or []
+        if len(points) == 2 and points[0] is not None and points[1] is not None:
+            text = f"{points[0]}-{points[1]}"
+            return f"TB {text}" if (score or {}).get("is_tiebreak") else text
+        return ""
+
+    def server_label(score):
+        return {1: "P1", 2: "P2"}.get((score or {}).get("server"), "")
+
+    def break_point(score):
+        """Derived marker: the receiver is one point from breaking serve.
+
+        Not a field the API sends — computed from `points` + `server`:
+        receiver at AD, or receiver at 40 while the server is below 40.
+        Tiebreaks are excluded (no break points in a tiebreak game).
+        """
+        if not score or score.get("is_tiebreak"):
+            return False
+        server = score.get("server")
+        points = score.get("points") or []
+        if server not in (1, 2) or len(points) != 2 or None in points:
+            return False
+        receiver_points = points[2 - server]
+        server_points = points[server - 1]
+        return receiver_points == "AD" or (
+            receiver_points == "40" and server_points in ("0", "15", "30")
+        )
+
+    def player_label(player):
+        if not player:
+            return ""
+        label = player.get("name") or ""
+        if player.get("country"):
+            label += f" ({player['country']})"
+        if player.get("ranking"):
+            label += f" · #{player['ranking']}"
+        return label
+
+    return break_point, fmt_games, fmt_points, fmt_sets, player_label, server_label
+
+
+@app.cell
+def _(
+    break_point,
+    fmt_games,
+    fmt_points,
+    fmt_sets,
+    live_matches,
+    mo,
+    player_search,
+    player_label,
+    server_label,
+    tour_select,
+):
+    _query = player_search.value.strip().lower()
+
+    def _keep(match):
+        if tour_select.value and match.get("tour") != tour_select.value:
+            return False
+        if _query:
+            players = match.get("players") or {}
+            names = " ".join(
+                (players.get(side) or {}).get("name") or ""
+                for side in ("p1", "p2")
+            ).lower()
+            return _query in names
+        return True
+
+    _rows = []
+    for _match in live_matches:
+        if not _keep(_match):
+            continue
+        _score = _match.get("score")
+        _players = _match.get("players") or {}
+        _serving = server_label(_score)
+        _bp = break_point(_score)
+        _rows.append(
+            {
+                "Tour": (_match.get("tour") or "").upper(),
+                "Tournament": _match.get("tournament") or "",
+                "Round": _match.get("round") or "",
+                "Player 1": player_label(_players.get("p1"))
+                + (" ●" if _serving == "P1" else ""),
+                "Player 2": player_label(_players.get("p2"))
+                + (" ●" if _serving == "P2" else ""),
+                "Sets": fmt_sets(_score),
+                "Games": fmt_games(_score),
+                "Points": fmt_points(_score),
+                "Break point": (
+                    "P2" if _serving == "P1" else "P1"
+                ) if _bp else "",
+            }
+        )
+
+    _live_view = (
+        mo.ui.table(_rows, selection=None, pagination=False)
+        if _rows
+        else mo.md("_No live matches match the current filters._")
+    )
+    mo.vstack(
+        [
+            mo.md(
+                f"## Live matches ({len(_rows)})\n"
+                "● = serving · **Break point** names the player one point from"
+                " breaking (derived from the score, tiebreaks excluded)."
+            ),
+            _live_view,
+        ]
+    )
+    return
+
+
+@app.cell
+def _(fixtures, is_sample, mo, player_search, tour_select):
+    _query = player_search.value.strip().lower()
+
+    def _keep(fixture):
+        # In live mode the API already applied the grouped ?tour= filter.
+        # Sample mode approximates it: Fixture.tour is the record's own
+        # granular value (e.g. "challenger_men"), so match by prefix.
+        if tour_select.value and is_sample:
+            if not (fixture.get("tour") or "").lower().startswith(
+                tour_select.value
+            ):
+                return False
+        if _query:
+            names = (
+                f"{fixture.get('player1_name') or ''}"
+                f" {fixture.get('player2_name') or ''}"
+            ).lower()
+            return _query in names
+        return True
+
+    _rows = [
+        {
+            "Starts (UTC)": fixture.get("start_time")
+            or fixture.get("event_date")
+            or "TBD",
+            "Tour": fixture.get("tour") or "",
+            "Tournament": fixture.get("tournament") or "",
+            "Round": fixture.get("round") or "",
+            "Player 1": fixture.get("player1_name") or "",
+            "Player 2": fixture.get("player2_name") or "",
+        }
+        for fixture in fixtures
+        if _keep(fixture)
+    ]
+
+    _fixtures_view = (
+        mo.ui.table(_rows, selection=None, pagination=False)
+        if _rows
+        else mo.md("_No upcoming fixtures match the current filters._")
+    )
+    mo.vstack([mo.md(f"## Upcoming fixtures ({len(_rows)})"), _fixtures_view])
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(
+        """
+        ---
+        **Adapting this notebook.** Everything above runs on two FREE
+        endpoints — `GET /matches?status=live` and `GET /fixtures` — of the
+        [Live Tennis API](https://docs.livetennisapi.com) (free tier: 30
+        requests/minute, 100/day; historical results and market prices are
+        paid tiers). Ideas: point the fetch cell at
+        `/matches?status=upcoming`, add a `country` filter, or join
+        `/players?search=` for player bios. Full spec:
+        [openapi.yaml](https://docs.livetennisapi.com/openapi.yaml).
+        """
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/live_tennis_dashboard/sample_data.json
+++ b/live_tennis_dashboard/sample_data.json
@@ -1,0 +1,253 @@
+{
+  "note": "Bundled SAMPLE data for the live-tennis marimo notebook. Player names are fictional. Shapes match the Live Tennis API OpenAPI spec (docs.livetennisapi.com/openapi.yaml): /matches?status=live and /fixtures responses.",
+  "matches": {
+    "data": [
+      {
+        "id": 910001,
+        "tournament": "Sample Open",
+        "tour": "atp",
+        "tournament_id": "sample-open-main",
+        "surface": "hard",
+        "indoor": false,
+        "format": "BO3",
+        "round": "Quarterfinal",
+        "round_code": "QF",
+        "status": "live",
+        "event_status": null,
+        "is_doubles": false,
+        "scheduled_time": "2026-08-16T11:00:00Z",
+        "players": {
+          "p1": { "id": 81001, "name": "Daniel Okafor", "tour": "atp", "country": "NG", "ranking": 14, "ranking_points": 2540, "hand": "R", "is_doubles_team": false },
+          "p2": { "id": 81002, "name": "Tomas Vanek", "tour": "atp", "country": "CZ", "ranking": 31, "ranking_points": 1385, "hand": "L", "is_doubles_team": false }
+        },
+        "score": {
+          "sets": [1, 0],
+          "games": [[6, 4], [3, 2]],
+          "points": ["30", "40"],
+          "server": 1,
+          "is_tiebreak": false,
+          "win_probability_p1": null,
+          "danger": null,
+          "timestamp": "2026-08-16T12:41:07Z"
+        },
+        "winner": null
+      },
+      {
+        "id": 910002,
+        "tournament": "Riverside Classic",
+        "tour": "wta",
+        "tournament_id": "riverside-classic-main",
+        "surface": "clay",
+        "indoor": false,
+        "format": "BO3",
+        "round": "Semifinal",
+        "round_code": "SF",
+        "status": "live",
+        "event_status": null,
+        "is_doubles": false,
+        "scheduled_time": "2026-08-16T10:30:00Z",
+        "players": {
+          "p1": { "id": 82001, "name": "Sofia Marchetti", "tour": "wta", "country": "IT", "ranking": 8, "ranking_points": 3910, "hand": "R", "is_doubles_team": false },
+          "p2": { "id": 82002, "name": "Hana Kobayashi", "tour": "wta", "country": "JP", "ranking": 22, "ranking_points": 1720, "hand": "R", "is_doubles_team": false }
+        },
+        "score": {
+          "sets": [0, 1],
+          "games": [[4, 6], [6, 6]],
+          "points": ["5", "3"],
+          "server": 2,
+          "is_tiebreak": true,
+          "win_probability_p1": null,
+          "danger": null,
+          "timestamp": "2026-08-16T12:40:32Z"
+        },
+        "winner": null
+      },
+      {
+        "id": 910003,
+        "tournament": "Harbor City Challenger",
+        "tour": "challenger",
+        "tournament_id": "harbor-city-ch",
+        "surface": "hard",
+        "indoor": true,
+        "format": "BO3",
+        "round": "Round of 16",
+        "round_code": "R16",
+        "status": "live",
+        "event_status": null,
+        "is_doubles": false,
+        "scheduled_time": "2026-08-16T12:00:00Z",
+        "players": {
+          "p1": { "id": 83001, "name": "Mateo Ibarra", "tour": "challenger_men", "country": "AR", "ranking": 134, "ranking_points": 470, "hand": "R", "is_doubles_team": false },
+          "p2": { "id": 83002, "name": "Felix Andersson", "tour": "challenger_men", "country": "SE", "ranking": 158, "ranking_points": 381, "hand": "R", "is_doubles_team": false }
+        },
+        "score": {
+          "sets": [0, 0],
+          "games": [[2], [3]],
+          "points": ["AD", "40"],
+          "server": 2,
+          "is_tiebreak": false,
+          "win_probability_p1": null,
+          "danger": null,
+          "timestamp": "2026-08-16T12:39:58Z"
+        },
+        "winner": null
+      },
+      {
+        "id": 910004,
+        "tournament": "Valley ITF W35",
+        "tour": "itf",
+        "tournament_id": "valley-itf-w35",
+        "surface": "clay",
+        "indoor": false,
+        "format": "BO3",
+        "round": "Final",
+        "round_code": "F",
+        "status": "live",
+        "event_status": null,
+        "is_doubles": false,
+        "scheduled_time": "2026-08-16T09:00:00Z",
+        "players": {
+          "p1": { "id": 84001, "name": "Leila Haddad", "tour": "itf_women", "country": "TN", "ranking": 412, "ranking_points": 96, "hand": "R", "is_doubles_team": false },
+          "p2": { "id": 84002, "name": "Petra Novakova", "tour": "itf_women", "country": "SK", "ranking": 388, "ranking_points": 104, "hand": "L", "is_doubles_team": false }
+        },
+        "score": {
+          "sets": [1, 1],
+          "games": [[6, 2, 4], [3, 6, 4]],
+          "points": ["15", "15"],
+          "server": 1,
+          "is_tiebreak": false,
+          "win_probability_p1": null,
+          "danger": null,
+          "timestamp": "2026-08-16T12:41:20Z"
+        },
+        "winner": null
+      },
+      {
+        "id": 910005,
+        "tournament": "Sample Open",
+        "tour": "atp",
+        "tournament_id": "sample-open-main",
+        "surface": "hard",
+        "indoor": false,
+        "format": "BO3",
+        "round": "Quarterfinal",
+        "round_code": "QF",
+        "status": "live",
+        "event_status": null,
+        "is_doubles": false,
+        "scheduled_time": "2026-08-16T12:15:00Z",
+        "players": {
+          "p1": { "id": 81003, "name": "Ruben Castillo", "tour": "atp", "country": "ES", "ranking": 5, "ranking_points": 5230, "hand": "R", "is_doubles_team": false },
+          "p2": { "id": 81004, "name": "Jonas Weber", "tour": "atp", "country": "DE", "ranking": 47, "ranking_points": 1010, "hand": "R", "is_doubles_team": false }
+        },
+        "score": {
+          "sets": [0, 0],
+          "games": [[5], [4]],
+          "points": ["40", "0"],
+          "server": 1,
+          "is_tiebreak": false,
+          "win_probability_p1": null,
+          "danger": null,
+          "timestamp": "2026-08-16T12:41:11Z"
+        },
+        "winner": null
+      }
+    ],
+    "meta": { "limit": 50, "offset": 0, "count": 5, "total": 5, "has_more": false }
+  },
+  "fixtures": {
+    "data": [
+      {
+        "id": 920001,
+        "event_date": "2026-08-16",
+        "start_time": "2026-08-16T15:00:00Z",
+        "player1_id": 81005,
+        "player2_id": 81006,
+        "tour": "atp",
+        "tournament": "Sample Open",
+        "round": "Quarterfinal",
+        "round_code": "QF",
+        "surface": "hard",
+        "player1_name": "Andrei Popescu",
+        "player2_name": "Louis Moreau",
+        "status": "scheduled"
+      },
+      {
+        "id": 920002,
+        "event_date": "2026-08-16",
+        "start_time": "2026-08-16T17:30:00Z",
+        "player1_id": 82003,
+        "player2_id": 82004,
+        "tour": "wta",
+        "tournament": "Riverside Classic",
+        "round": "Semifinal",
+        "round_code": "SF",
+        "surface": "clay",
+        "player1_name": "Emma Lindqvist",
+        "player2_name": "Carla Duarte",
+        "status": "scheduled"
+      },
+      {
+        "id": 920003,
+        "event_date": "2026-08-17",
+        "start_time": null,
+        "player1_id": 83003,
+        "player2_id": null,
+        "tour": "challenger_men",
+        "tournament": "Harbor City Challenger",
+        "round": "Round of 16",
+        "round_code": "R16",
+        "surface": "hard",
+        "player1_name": "Igor Melnyk",
+        "player2_name": "Sam Whitfield",
+        "status": "scheduled"
+      },
+      {
+        "id": 920004,
+        "event_date": "2026-08-17",
+        "start_time": "2026-08-17T08:00:00Z",
+        "player1_id": null,
+        "player2_id": null,
+        "tour": "itf_men",
+        "tournament": "Lakeside ITF M25",
+        "round": "Semifinal",
+        "round_code": "SF",
+        "surface": "clay",
+        "player1_name": "Niko Virtanen",
+        "player2_name": "Bruno Silva",
+        "status": "scheduled"
+      },
+      {
+        "id": 920005,
+        "event_date": "2026-08-17",
+        "start_time": "2026-08-17T11:00:00Z",
+        "player1_id": null,
+        "player2_id": null,
+        "tour": "juniors_girls",
+        "tournament": "Junior Slam Sample",
+        "round": "Round of 32",
+        "round_code": "R32",
+        "surface": "grass",
+        "player1_name": "Maya Chen",
+        "player2_name": "Alice Fontaine",
+        "status": "scheduled"
+      },
+      {
+        "id": 920006,
+        "event_date": "2026-08-18",
+        "start_time": "2026-08-18T13:00:00Z",
+        "player1_id": 81001,
+        "player2_id": 81003,
+        "tour": "atp",
+        "tournament": "Sample Open",
+        "round": "Semifinal",
+        "round_code": "SF",
+        "surface": "hard",
+        "player1_name": "Daniel Okafor",
+        "player2_name": "Ruben Castillo",
+        "status": "scheduled"
+      }
+    ],
+    "meta": { "limit": 25, "offset": 0, "count": 6, "total": 6, "has_more": false }
+  }
+}


### PR DESCRIPTION
## Summary

A reactive live-tennis scoreboard: live matches (set score, in-game points, serving marker, and a break-point marker derived from the raw score) plus upcoming fixtures, filterable by tour and player name. Data comes from the [Live Tennis API](https://livetennisapi.com); **the notebook renders without an API key** using bundled, clearly-labeled sample data (with a small inline fallback so the playground badge works too), and a free key unlocks the real live picture.

The notebook is polite to the API's free-tier budget (30 req/min, 100/day): refresh is manual by default and the optional `mo.ui.refresh` intervals are capped at 1 minute or slower, with the budget spelled out next to the control.

## Contribution checklist

- [x] Example is in its own folder (`live_tennis_dashboard/`)
- [x] Package dependencies are in the notebook file as `--sandbox` inline script metadata (`marimo`, `requests`)
- [x] Folder README describes the example and how to run it (playground badge + `uvx marimo edit --sandbox`)
- [x] README includes instructions for adapting the notebook (using your own key, other endpoints/filters, extending the break-point logic)

Verified headlessly: `uvx marimo export html --sandbox live_tennis_dashboard.py` succeeds with no key and renders the sample data (that export is the screenshot in the README).

**Disclosure:** I maintain the Live Tennis API.
